### PR TITLE
Add cohort rules editor with validation and overrides

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { Upload, Download, RotateCcw, TrendingUp, Search, Target } from 'lucide-react';
 import * as XLSX from 'xlsx';
+import CohortRulesEditor from './components/CohortRulesEditor';
 
 interface KeywordData {
   keyword: string;
@@ -50,7 +51,7 @@ function App() {
         const worksheet = workbook.Sheets[sheetName];
         const jsonData = XLSX.utils.sheet_to_json(worksheet);
 
-        const parsedKeywords: KeywordData[] = jsonData.map((row: any) => {
+        const parsedKeywords: KeywordData[] = jsonData.map((row: Record<string, unknown>) => {
           // Handle SEMrush and other common column naming conventions
           const keyword = row.Keyword || row.keyword || row.KEYWORD || row.query || row.Query || row['Query'] || '';
           const position = parseInt(row.Position || row.position || row.POSITION || row.rank || row.Rank || row['Avg. Position'] || '0');
@@ -246,15 +247,17 @@ function App() {
     <div className="min-h-screen bg-gray-50 p-6">
       <div className="max-w-7xl mx-auto space-y-8">
         {/* Header */}
-        <div className="text-center">
-          <h1 className="text-4xl font-bold text-gray-900 mb-2">SEMrush Keyword Analyzer</h1>
-          <p className="text-gray-600">Upload your keyword data and analyze traffic potential</p>
-        </div>
+          <div className="text-center">
+            <h1 className="text-4xl font-bold text-gray-900 mb-2">SEMrush Keyword Analyzer</h1>
+            <p className="text-gray-600">Upload your keyword data and analyze traffic potential</p>
+          </div>
 
-        {/* File Upload Section */}
-        <div className="bg-white rounded-lg shadow-md p-6">
-          <h2 className="text-2xl font-semibold text-gray-900 mb-4 flex items-center">
-            <Upload className="mr-2" size={24} />
+          <CohortRulesEditor />
+
+          {/* File Upload Section */}
+          <div className="bg-white rounded-lg shadow-md p-6">
+            <h2 className="text-2xl font-semibold text-gray-900 mb-4 flex items-center">
+              <Upload className="mr-2" size={24} />
             File Upload
           </h2>
           <div

--- a/src/components/CohortRulesEditor.tsx
+++ b/src/components/CohortRulesEditor.tsx
@@ -1,0 +1,211 @@
+import React, { useState } from 'react';
+
+type Cohort = 'A' | 'B' | 'C';
+
+interface CohortRule {
+  positionFrom: string;
+  positionTo: string;
+  kdFrom: string;
+  kdTo: string;
+  serp: string;
+  intent: string;
+  country: string;
+  device: string;
+  probA: string;
+  probB: string;
+  probC: string;
+  cohortOverride: '' | Cohort;
+}
+
+const createEmptyRule = (): CohortRule => ({
+  positionFrom: '',
+  positionTo: '',
+  kdFrom: '',
+  kdTo: '',
+  serp: '',
+  intent: '',
+  country: '',
+  device: '',
+  probA: '0.3',
+  probB: '0.3',
+  probC: '0.3',
+  cohortOverride: ''
+});
+
+const CohortRulesEditor: React.FC = () => {
+  const [rules, setRules] = useState<CohortRule[]>([createEmptyRule()]);
+
+  const updateRule = (index: number, field: keyof CohortRule, value: string) => {
+    setRules(prev => prev.map((r, i) => (i === index ? { ...r, [field]: value } : r)));
+  };
+
+  const addRule = () => {
+    setRules(prev => [...prev, createEmptyRule()]);
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-2xl font-semibold text-gray-900">Cohort Rules Editor</h2>
+        <button
+          onClick={addRule}
+          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700"
+        >
+          Add Rule
+        </button>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200 text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-2 py-3 text-left font-medium text-gray-500">Position</th>
+              <th className="px-2 py-3 text-left font-medium text-gray-500">KD</th>
+              <th className="px-2 py-3 text-left font-medium text-gray-500">SERP Features</th>
+              <th className="px-2 py-3 text-left font-medium text-gray-500">Intent</th>
+              <th className="px-2 py-3 text-left font-medium text-gray-500">Country</th>
+              <th className="px-2 py-3 text-left font-medium text-gray-500">Device</th>
+              <th className="px-2 py-3 text-left font-medium text-gray-500">A</th>
+              <th className="px-2 py-3 text-left font-medium text-gray-500">B</th>
+              <th className="px-2 py-3 text-left font-medium text-gray-500">C</th>
+              <th className="px-2 py-3 text-left font-medium text-gray-500">B1120</th>
+              <th className="px-2 py-3 text-left font-medium text-gray-500">Override</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {rules.map((rule, idx) => {
+              const a = parseFloat(rule.probA) || 0;
+              const b = parseFloat(rule.probB) || 0;
+              const c = parseFloat(rule.probC) || 0;
+              const sum = a + b + c;
+              const leftover = sum <= 1 ? 1 - sum : 0;
+              const error = sum > 1;
+              return (
+                <tr key={idx} className={error ? 'bg-red-50' : ''}>
+                  <td className="px-2 py-2">
+                    <div className="flex space-x-1">
+                      <input
+                        type="number"
+                        value={rule.positionFrom}
+                        onChange={e => updateRule(idx, 'positionFrom', e.target.value)}
+                        className="w-16 border rounded px-1 py-0.5"
+                        placeholder="from"
+                      />
+                      <input
+                        type="number"
+                        value={rule.positionTo}
+                        onChange={e => updateRule(idx, 'positionTo', e.target.value)}
+                        className="w-16 border rounded px-1 py-0.5"
+                        placeholder="to"
+                      />
+                    </div>
+                  </td>
+                  <td className="px-2 py-2">
+                    <div className="flex space-x-1">
+                      <input
+                        type="number"
+                        value={rule.kdFrom}
+                        onChange={e => updateRule(idx, 'kdFrom', e.target.value)}
+                        className="w-16 border rounded px-1 py-0.5"
+                        placeholder="from"
+                      />
+                      <input
+                        type="number"
+                        value={rule.kdTo}
+                        onChange={e => updateRule(idx, 'kdTo', e.target.value)}
+                        className="w-16 border rounded px-1 py-0.5"
+                        placeholder="to"
+                      />
+                    </div>
+                  </td>
+                  <td className="px-2 py-2">
+                    <input
+                      type="text"
+                      value={rule.serp}
+                      onChange={e => updateRule(idx, 'serp', e.target.value)}
+                      className="w-32 border rounded px-1 py-0.5"
+                    />
+                  </td>
+                  <td className="px-2 py-2">
+                    <input
+                      type="text"
+                      value={rule.intent}
+                      onChange={e => updateRule(idx, 'intent', e.target.value)}
+                      className="w-24 border rounded px-1 py-0.5"
+                    />
+                  </td>
+                  <td className="px-2 py-2">
+                    <input
+                      type="text"
+                      value={rule.country}
+                      onChange={e => updateRule(idx, 'country', e.target.value)}
+                      className="w-24 border rounded px-1 py-0.5"
+                    />
+                  </td>
+                  <td className="px-2 py-2">
+                    <input
+                      type="text"
+                      value={rule.device}
+                      onChange={e => updateRule(idx, 'device', e.target.value)}
+                      className="w-24 border rounded px-1 py-0.5"
+                    />
+                  </td>
+                  <td className="px-2 py-2">
+                    <input
+                      type="number"
+                      min="0"
+                      max="1"
+                      step="0.01"
+                      value={rule.probA}
+                      onChange={e => updateRule(idx, 'probA', e.target.value)}
+                      className="w-16 border rounded px-1 py-0.5"
+                    />
+                  </td>
+                  <td className="px-2 py-2">
+                    <input
+                      type="number"
+                      min="0"
+                      max="1"
+                      step="0.01"
+                      value={rule.probB}
+                      onChange={e => updateRule(idx, 'probB', e.target.value)}
+                      className="w-16 border rounded px-1 py-0.5"
+                    />
+                  </td>
+                  <td className="px-2 py-2">
+                    <input
+                      type="number"
+                      min="0"
+                      max="1"
+                      step="0.01"
+                      value={rule.probC}
+                      onChange={e => updateRule(idx, 'probC', e.target.value)}
+                      className="w-16 border rounded px-1 py-0.5"
+                    />
+                  </td>
+                  <td className="px-2 py-2">
+                    <span className={error ? 'text-red-600 font-medium' : ''}>{leftover.toFixed(2)}</span>
+                  </td>
+                  <td className="px-2 py-2">
+                    <select
+                      value={rule.cohortOverride}
+                      onChange={e => updateRule(idx, 'cohortOverride', e.target.value)}
+                      className="border rounded px-1 py-0.5"
+                    >
+                      <option value="">None</option>
+                      <option value="A">A</option>
+                      <option value="B">B</option>
+                      <option value="C">C</option>
+                    </select>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default CohortRulesEditor;
+


### PR DESCRIPTION
## Summary
- add cohort rules editor to define cohort conditions and probabilities
- validate probabilities, assign leftover to B1120, and support per-row overrides
- integrate cohort rules editor into main app

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899b25f5650832489a207acf2efdc0a